### PR TITLE
Add CMake tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.10)
+project(ChessEngine CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_library(chess_engine
+    src/board.cpp
+    src/moveGenerator.cpp
+    src/utils.cpp
+    src/eval.cpp
+    src/search.cpp
+)
+
+# Include headers for the library
+ target_include_directories(chess_engine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+add_executable(chess_main src/main.cpp)
+target_link_libraries(chess_main chess_engine)
+
+# Tests
+enable_testing()
+add_executable(test_movegenerator tests/test_movegenerator.cpp)
+target_link_libraries(test_movegenerator chess_engine)
+add_test(NAME test_movegenerator COMMAND test_movegenerator)
+set_tests_properties(test_movegenerator PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_executable(test_all_perfts tests/test_all_perfts.cpp)
+target_link_libraries(test_all_perfts chess_engine)
+add_test(NAME test_all_perfts COMMAND test_all_perfts)
+set_tests_properties(test_all_perfts PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+# Optional benchmark based on gperftools. Disabled by default because it can
+# take a long time to run. Uncomment the following lines to build the
+# benchmark when gperftools is available.
+# find_package(Threads REQUIRED)
+# find_library(GPERFTOOLS_LIB profiler)
+# if(GPERFTOOLS_LIB)
+#   message(STATUS "Found gperftools: ${GPERFTOOLS_LIB}")
+#   add_executable(test_perft tests/test_perft.cpp)
+#   target_link_libraries(test_perft chess_engine ${GPERFTOOLS_LIB} Threads::Threads)
+#   add_test(NAME test_perft COMMAND test_perft)
+# endif()

--- a/src/board.h
+++ b/src/board.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <cctype>
 #include <vector>
+#include <cstdint>
 #include "types.h"
 #include "moveGenerator.h"// Represent the type of piece.
 

--- a/src/types.h
+++ b/src/types.h
@@ -3,6 +3,7 @@
 #define TYPES_H
 #include <cctype>
 #include <array>
+#include <cstdint>
 enum class PieceType { PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING,NONE };
 enum class Color { WHITE, BLACK, NONE };
 enum Square {

--- a/tests/standard.epd
+++ b/tests/standard.epd
@@ -1,0 +1,1 @@
+rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 D3 20 400 8902

--- a/tests/test_all_perfts.cpp
+++ b/tests/test_all_perfts.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <chrono>
 #include <vector>
 #include <string>
 #include <cassert>


### PR DESCRIPTION
## Summary
- add CMake build system with simple tests
- create small perft dataset
- include `<cstdint>` in headers for `uint64_t`
- update all-perft test to include `<chrono>`

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_683f88e5b8888320861901810d099bc5